### PR TITLE
Fix error checking to Go 1.13, clean code

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,16 @@
 package config
 
 import (
-	"github.com/go-ozzo/ozzo-validation/v3"
+	validation "github.com/go-ozzo/ozzo-validation/v3"
 	"github.com/qiangxue/go-env"
 	"github.com/qiangxue/go-restful-api/pkg/log"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
+)
+
+const (
+	DefaultServerPort         = 8080
+	DefaultJWTExpirationHours = 72
 )
 
 // Config represents an application configuration.
@@ -35,8 +40,8 @@ func (c Config) Validate() error {
 func Load(file string, logger log.Logger) (*Config, error) {
 	// default config
 	c := Config{
-		ServerPort:    8080,
-		JWTExpiration: 72,
+		ServerPort:    DefaultServerPort,
+		JWTExpiration: DefaultJWTExpirationHours,
 	}
 
 	// load from YAML config file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	validation "github.com/go-ozzo/ozzo-validation/v3"
+	"github.com/go-ozzo/ozzo-validation/v3"
 	"github.com/qiangxue/go-env"
 	"github.com/qiangxue/go-restful-api/pkg/log"
 	"gopkg.in/yaml.v2"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	DefaultServerPort         = 8080
-	DefaultJWTExpirationHours = 72
+	defaultServerPort         = 8080
+	defaultJWTExpirationHours = 72
 )
 
 // Config represents an application configuration.
@@ -40,8 +40,8 @@ func (c Config) Validate() error {
 func Load(file string, logger log.Logger) (*Config, error) {
 	// default config
 	c := Config{
-		ServerPort:    DefaultServerPort,
-		JWTExpiration: DefaultJWTExpirationHours,
+		ServerPort:    defaultServerPort,
+		JWTExpiration: defaultJWTExpirationHours,
 	}
 
 	// load from YAML config file

--- a/internal/errors/middleware.go
+++ b/internal/errors/middleware.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	routing "github.com/go-ozzo/ozzo-routing/v2"
 	validation "github.com/go-ozzo/ozzo-validation/v3"
@@ -58,10 +59,10 @@ func buildErrorResponse(err error) ErrorResponse {
 				Message: err.Error(),
 			}
 		}
-	default:
-		if err == sql.ErrNoRows {
-			return NotFound("")
-		}
-		return InternalServerError("")
 	}
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return NotFound("")
+	}
+	return InternalServerError("")
 }


### PR DESCRIPTION
- new Go 1.13 approach to check errors
- move default from the switch to not be complex with internal switch