### PR TITLE
Fix Github Actions build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: make lint
 
       - name: Build
-        run: make lint
+        run: make build
 
       - name: Test
         env:


### PR DESCRIPTION
`build` step should be next to `link`